### PR TITLE
Swerve hot fix for the bug with the spinning wheels.

### DIFF
--- a/code/src/main/java/frc/robot/commands/navcommands/TrackVisionTarget.java
+++ b/code/src/main/java/frc/robot/commands/navcommands/TrackVisionTarget.java
@@ -54,6 +54,7 @@ public class TrackVisionTarget extends DrivetrainCommandBase {
     @Override
     public void end(boolean interrupted) {
         super.end(interrupted);
+        _drivetrain.move(0, 0, 0, true);
         _limelight.setLEDState(1);
     }
 

--- a/code/src/main/java/frc/robot/subsystems/SwerveDrivetrain.java
+++ b/code/src/main/java/frc/robot/subsystems/SwerveDrivetrain.java
@@ -173,15 +173,13 @@ public class SwerveDrivetrain extends TraceableSubsystem implements IDrivetrainS
 
                         // Sets the setpoint to maintain the heading the tick after you release the
                         // joystick
-
                 } else if (_theta == 0.0 && this.m_isTurning) {
                         this.m_pidController.setSetpoint((((this.m_gyro.getAngle() % 360) + 360) % 360));
                         this.m_isTurning = false;
                         _theta = this.m_pidController.calculate((((this.m_gyro.getAngle() % 360) + 360) % 360));
-
                 }
-                // applies heading correction only when moving and not sending a input command
-                else if (_x != 0 && _y != 0) {
+                // applies heading correction only when translating but not rotating
+                else if (_x != 0 || _y != 0) {
                         _theta = this.m_pidController.calculate((((this.m_gyro.getAngle() % 360) + 360) % 360));
                 }
 


### PR DESCRIPTION
We realized that the logic would only be called when move was being called. this was not a problem for tele-op as move was called every tick, but during auto we needed it to remember the last command we gave it, so the bot will stop spinning if it didn't lock on. 