### PR TITLE
swerve wheels dont change heading when stop moving

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": true
+}

--- a/code/src/main/java/frc/robot/RobotConfig.java
+++ b/code/src/main/java/frc/robot/RobotConfig.java
@@ -75,6 +75,7 @@ public final class RobotConfig {
         public final int rearLeftAbsoluteEncoder = 3;
         public final int rearRightAbsoluteEncoder = 2;
 
+        public final double gyroRateDeadzone = 0.05;
     }
 
     public final class Physical {

--- a/code/src/main/java/frc/robot/subsystems/SwerveDrivetrain.java
+++ b/code/src/main/java/frc/robot/subsystems/SwerveDrivetrain.java
@@ -22,6 +22,7 @@ import edu.wpi.first.wpilibj.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.wpilibj.kinematics.SwerveModuleState;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import frc.robot.RobotConfig;
+import frc.robot.commands.Util;
 import frc.robot.common.AbsoluteEncoder;
 import frc.robot.common.IDrivetrainSubsystem;
 import frc.robot.common.ILogger;
@@ -60,7 +61,6 @@ public class SwerveDrivetrain extends TraceableSubsystem implements IDrivetrainS
         private double _theta;
         private boolean _isFieldRelative;
         private boolean _isTurning;
-        private SwerveModuleState[] _previousSwerveStates;
 
         @Inject
         public SwerveDrivetrain(final ILogger logger, final RobotConfig config) {
@@ -169,12 +169,13 @@ public class SwerveDrivetrain extends TraceableSubsystem implements IDrivetrainS
 
         public void periodic() {
                 // Drag Heading Correction
-                if (_theta != 0.0) {
+                if (Util.deadZones(m_gyro.getRate(), _config.Drivetrain.gyroRateDeadzone) != 0.0) {
                         _isTurning = true;
 
                         // Sets the setpoint to maintain the heading the tick after you release the
                         // joystick
-                } else if (_theta == 0.0 && this._isTurning) {
+                } else if (Util.deadZones(m_gyro.getRate(), _config.Drivetrain.gyroRateDeadzone) == 0.0
+                                && this._isTurning) {
                         this._pidController.setSetpoint((((this.m_gyro.getAngle() % 360) + 360) % 360));
                         this._isTurning = false;
                         _theta = this._pidController.calculate((((this.m_gyro.getAngle() % 360) + 360) % 360));
@@ -184,6 +185,7 @@ public class SwerveDrivetrain extends TraceableSubsystem implements IDrivetrainS
                         _theta = this._pidController.calculate((((this.m_gyro.getAngle() % 360) + 360) % 360));
                 }
 
+                // adding static friction
                 if (_x != 0) {
                         _x += (_x / Math.abs(_x)) * (_config.Physical.staticFrictionConstant);
                 }
@@ -233,9 +235,8 @@ public class SwerveDrivetrain extends TraceableSubsystem implements IDrivetrainS
                 // SmartDashboard.putNumber("front left ", m_frontLeftEncoder.getRadians());
                 // SmartDashboard.putNumber("front right ", m_frontRightEncoder.getRadians());
                 SmartDashboard.putNumber("Gyro VAlue", ((m_gyro.getAngle() % 360) + 360) % 360);
-                // SmartDashboard.putNumber("gyro angle fed to field relative ",
-                // (360 - (this.m_gyro.getAngle() % (360)) + (360)) % (360));
-
+                SmartDashboard.putNumber("gyro rate ", m_gyro.getRate());
+                SmartDashboard.putBoolean("Is turning ", _isTurning);
                 // SmartDashboard.putNumber("heading pid error ",
                 // this.m_pidController.getPositionError());
                 // SmartDashboard.putBoolean("is turning ", this.m_isTurning);

--- a/code/src/main/java/frc/robot/subsystems/SwerveDrivetrain.java
+++ b/code/src/main/java/frc/robot/subsystems/SwerveDrivetrain.java
@@ -52,14 +52,15 @@ public class SwerveDrivetrain extends TraceableSubsystem implements IDrivetrainS
         public AbsoluteEncoder m_backLeftEncoder;
         public CANEncoder m_leftdrive;
         public CANEncoder m_leftturn;
-        private SwerveDriveKinematics m_kinematics;
         private AHRS m_gyro;
-        private PIDController m_pidController;
+        private SwerveDriveKinematics _kinematics;
+        private PIDController _pidController;
         private double _x;
         private double _y;
         private double _theta;
-        private boolean isFieldRelative;
-        private boolean m_isTurning;
+        private boolean _isFieldRelative;
+        private boolean _isTurning;
+        private SwerveModuleState[] _previousSwerveStates;
 
         @Inject
         public SwerveDrivetrain(final ILogger logger, final RobotConfig config) {
@@ -97,13 +98,13 @@ public class SwerveDrivetrain extends TraceableSubsystem implements IDrivetrainS
                 m_backRightEncoder = new AbsoluteEncoder(config.Drivetrain.rearRightAbsoluteEncoder, 3.925, true);
                 m_backRight = new SwerveWheel(m_backRightDrive, m_backRightTurn, -widthOffset, -lengthOffset,
                                 m_backRightEncoder, "Right back");
-                m_kinematics = new SwerveDriveKinematics(m_frontLeft.getlocation(), m_frontRight.getlocation(),
+                _kinematics = new SwerveDriveKinematics(m_frontLeft.getlocation(), m_frontRight.getlocation(),
                                 m_backLeft.getlocation(), m_backRight.getlocation());
 
-                m_pidController = new PIDController((getMaxSpeed() / 180) * 5, 0, 0);
+                _pidController = new PIDController((getMaxSpeed() / 180) * 5, 0, 0);
 
-                m_pidController.enableContinuousInput(0, 360);
-                m_pidController.setTolerance(10);
+                _pidController.enableContinuousInput(0, 360);
+                _pidController.setTolerance(10);
 
                 m_gyro = new AHRS(SPI.Port.kMXP);
 
@@ -113,7 +114,7 @@ public class SwerveDrivetrain extends TraceableSubsystem implements IDrivetrainS
 
         public void resetGyro() {
                 this.m_gyro.reset();
-                this.m_pidController.setSetpoint(0);
+                this._pidController.setSetpoint(0);
                 DriverStation.reportError("gyro reset ", false);
         }
 
@@ -140,7 +141,7 @@ public class SwerveDrivetrain extends TraceableSubsystem implements IDrivetrainS
                 _x = x;
                 _y = y;
                 _theta = theta;
-                isFieldRelative = fieldRelative;
+                _isFieldRelative = fieldRelative;
 
                 // this.getLogger("frontLeft: ", m)
                 SmartDashboard.putNumber("subsystem m/s x", x);
@@ -169,18 +170,18 @@ public class SwerveDrivetrain extends TraceableSubsystem implements IDrivetrainS
         public void periodic() {
                 // Drag Heading Correction
                 if (_theta != 0.0) {
-                        m_isTurning = true;
+                        _isTurning = true;
 
                         // Sets the setpoint to maintain the heading the tick after you release the
                         // joystick
-                } else if (_theta == 0.0 && this.m_isTurning) {
-                        this.m_pidController.setSetpoint((((this.m_gyro.getAngle() % 360) + 360) % 360));
-                        this.m_isTurning = false;
-                        _theta = this.m_pidController.calculate((((this.m_gyro.getAngle() % 360) + 360) % 360));
+                } else if (_theta == 0.0 && this._isTurning) {
+                        this._pidController.setSetpoint((((this.m_gyro.getAngle() % 360) + 360) % 360));
+                        this._isTurning = false;
+                        _theta = this._pidController.calculate((((this.m_gyro.getAngle() % 360) + 360) % 360));
                 }
                 // applies heading correction only when translating but not rotating
                 else if (_x != 0 || _y != 0) {
-                        _theta = this.m_pidController.calculate((((this.m_gyro.getAngle() % 360) + 360) % 360));
+                        _theta = this._pidController.calculate((((this.m_gyro.getAngle() % 360) + 360) % 360));
                 }
 
                 if (_x != 0) {
@@ -200,28 +201,39 @@ public class SwerveDrivetrain extends TraceableSubsystem implements IDrivetrainS
                 SwerveModuleState[] swerveModuleStates;
 
                 // Field relative conversion
-                if (isFieldRelative) {
-                        swerveModuleStates = m_kinematics.toSwerveModuleStates(
+                if (_isFieldRelative) {
+                        swerveModuleStates = _kinematics.toSwerveModuleStates(
                                         ChassisSpeeds.fromFieldRelativeSpeeds(_x, _y, _theta, new Rotation2d(2 * Math.PI
                                                         - Math.toRadians(((m_gyro.getAngle() % 360) + 360) % 360))));
                 } else {
-                        swerveModuleStates = m_kinematics.toSwerveModuleStates(new ChassisSpeeds(_x, _y, _theta));
+                        swerveModuleStates = _kinematics.toSwerveModuleStates(new ChassisSpeeds(_x, _y, _theta));
                 }
                 SwerveDriveKinematics.normalizeWheelSpeeds(swerveModuleStates, this.getMaxSpeed());
                 // order of wheels in swerve module states is the same order as the wheels being
                 // inputed to Swerve kinematics
-                m_frontLeft.setDesiredState(swerveModuleStates[0], this.getMaxSpeed());
-                m_frontRight.setDesiredState(swerveModuleStates[1], this.getMaxSpeed());
-                m_backLeft.setDesiredState(swerveModuleStates[2], this.getMaxSpeed());
-                m_backRight.setDesiredState(swerveModuleStates[3], this.getMaxSpeed());
+
+                // if the drivetrain is told to stop moving, the headings of the wheels will not
+                // be changed, just the speeds.
+                // This is so that it will drift better when the drive wheels are on coast mode.
+                if (_x == 0 && _y == 0 && _theta == 0) {
+                        m_frontLeft.setVelocity(0, this.getMaxSpeed());
+                        m_frontRight.setVelocity(0, this.getMaxSpeed());
+                        m_backLeft.setVelocity(0, this.getMaxSpeed());
+                        m_backRight.setVelocity(0, this.getMaxSpeed());
+                } else {
+                        m_frontLeft.setDesiredState(swerveModuleStates[0], this.getMaxSpeed());
+                        m_frontRight.setDesiredState(swerveModuleStates[1], this.getMaxSpeed());
+                        m_backLeft.setDesiredState(swerveModuleStates[2], this.getMaxSpeed());
+                        m_backRight.setDesiredState(swerveModuleStates[3], this.getMaxSpeed());
+                }
+
                 // Debugging output mostly
                 // SmartDashboard.putNumber("back left ", m_backLeftEncoder.getRadians());
                 // SmartDashboard.putNumber("back right ", m_backRightEncoder.getRadians());
                 // SmartDashboard.putNumber("front left ", m_frontLeftEncoder.getRadians());
                 // SmartDashboard.putNumber("front right ", m_frontRightEncoder.getRadians());
                 SmartDashboard.putNumber("Gyro VAlue", ((m_gyro.getAngle() % 360) + 360) % 360);
-
-                                // SmartDashboard.putNumber("gyro angle fed to field relative ",
+                // SmartDashboard.putNumber("gyro angle fed to field relative ",
                 // (360 - (this.m_gyro.getAngle() % (360)) + (360)) % (360));
 
                 // SmartDashboard.putNumber("heading pid error ",

--- a/code/src/main/java/frc/robot/subsystems/SwerveWheel.java
+++ b/code/src/main/java/frc/robot/subsystems/SwerveWheel.java
@@ -115,13 +115,17 @@ public class SwerveWheel {
   }
 
   /**
-   * Sets only the velocity of the wheel, does not change the heading. 
+   * Sets only the velocity of the wheel, does not change the heading. Still sets
+   * the turning motor to the pid controller's calculated output from the previous
+   * heading.
+   * 
    * @param metersPerSecond the speed of the wheel in meters per second
-   * @param maxWheelSpeed the maximum speed of a wheel in meters/second. use the
-   *                      getMaxSpeed() method of the drivetrain
+   * @param maxWheelSpeed   the maximum speed of a wheel in meters/second. use the
+   *                        getMaxSpeed() method of the drivetrain
    */
   public void setVelocity(double metersPerSecond, double maxWheelSpeed) {
     m_driveMotor.set(metersPerSecond / maxWheelSpeed);
+    m_turningMotor.set(m_turningPIDController.calculate(m_turningEncoder.getRadians()));
   }
 
   /**

--- a/code/src/main/java/frc/robot/subsystems/SwerveWheel.java
+++ b/code/src/main/java/frc/robot/subsystems/SwerveWheel.java
@@ -31,7 +31,7 @@ public class SwerveWheel {
   private final Translation2d m_location;
   private final CANEncoder m_driveEncoder;
   private final AbsoluteEncoder m_turningEncoder;
-  private double PIDOutput;
+  private double m_pidOutput;
 
   // private final PIDController m_drivePIDController = new PIDController(1, 0,
   // 0);
@@ -54,7 +54,7 @@ public class SwerveWheel {
    */
   public SwerveWheel(CANSparkMax driveMotor, CANSparkMax turningMotor, double X, double Y, AbsoluteEncoder turnEncoder,
       String name) {
-    PIDOutput = 0;
+    m_pidOutput = 0;
     m_name = name;
     m_driveMotor = driveMotor;
     m_turningMotor = turningMotor;
@@ -109,9 +109,19 @@ public class SwerveWheel {
     driveOutput = smartInversion(state.angle.getRadians(), driveOutput);
 
     m_driveMotor.set(driveOutput);
-    PIDOutput = m_turningPIDController.calculate(m_turningEncoder.getRadians());
-    m_turningMotor.set(PIDOutput);
+    m_pidOutput = m_turningPIDController.calculate(m_turningEncoder.getRadians());
+    m_turningMotor.set(m_pidOutput);
 
+  }
+
+  /**
+   * Sets only the velocity of the wheel, does not change the heading. 
+   * @param metersPerSecond the speed of the wheel in meters per second
+   * @param maxWheelSpeed the maximum speed of a wheel in meters/second. use the
+   *                      getMaxSpeed() method of the drivetrain
+   */
+  public void setVelocity(double metersPerSecond, double maxWheelSpeed) {
+    m_driveMotor.set(metersPerSecond / maxWheelSpeed);
   }
 
   /**
@@ -143,6 +153,6 @@ public class SwerveWheel {
   }
 
   public double getPID() {
-    return this.PIDOutput;
+    return this.m_pidOutput;
   }
 }


### PR DESCRIPTION
If we are getting 0 from all of the velocity inputs, it only sets the swerve wheel velocities to 0, without changing the heading of the wheel.  This makes it so that the wheels don't go facing robot-forward every time we stop driving, and the bot will actually drift in other directions other than forward when the motors are on coast mode.